### PR TITLE
Remove the old engines (node version) limitation

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,6 @@
   "name": "intergram",
   "version": "0.0.1",
   "description": "A live chat widget linked to your telegram messenger",
-  "engines": {
-    "node": "6.9.1",
-    "npm": "3.10.8"
-  },
   "scripts": {
     "start": "node server.js",
     "dev": "start  http://localhost:3000/demo.html & node devServer.js",
@@ -32,13 +28,13 @@
     "cors": "^2.8.1",
     "dateformat": "^2.0.0",
     "eslint": "^3.2.2",
-    "express": "4.10.2",
+    "express": "^4.16.4"",
     "human-readable-ids": "^1.0.4",
     "preact": "^7.1.0",
     "request": "^2.79.0",
     "shx": "^0.2.2",
-    "socket.io": "^1.7.3",
-    "socket.io-client": "^1.7.3",
+    "socket.io": "^2.2.0",
+    "socket.io-client": "^2.2.0",
     "store": "^1.3.20",
     "webpack": "^1.14.0",
     "whatwg-fetch": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "cors": "^2.8.1",
     "dateformat": "^2.0.0",
     "eslint": "^3.2.2",
-    "express": "^4.16.4"",
+    "express": "^4.16.4",
     "human-readable-ids": "^1.0.4",
     "preact": "^7.1.0",
     "request": "^2.79.0",


### PR DESCRIPTION
This package also works on all newer versions of node, so there is no reason to limit it to the old node version 6.9.1.